### PR TITLE
Patchwork fix for Windows dev. environment.

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -714,11 +714,14 @@ namespace dotBunny.Unity
             if (content.Length == 0)
                 return "";
 
+// Note: it causes OmniSharp faults on Windows, such as "not seeing UnityEngine.UI". 3.5 target works fine
+#if !UNITY_EDITOR_WIN
             // Make sure our reference framework is 2.0, still the base for Unity
             if (content.IndexOf("<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>") != -1)
             {
                 content = Regex.Replace(content, "<TargetFrameworkVersion>v3.5</TargetFrameworkVersion>", "<TargetFrameworkVersion>v2.0</TargetFrameworkVersion>");
             }
+#endif
 
             string targetPath = "";// "<TargetPath>Temp" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "Debug" + Path.DirectorySeparatorChar + "</TargetPath>"; //OutputPath
             string langVersion = "<LangVersion>default</LangVersion>";


### PR DESCRIPTION
Basically, switching target to 2.0 causes all sorts of hell to break loose on Windows. No idea why it works on Mac the way it is, though.

More info:
http://stackoverflow.com/questions/33307399/unity3d-project-crashes-vscode

https://code.visualstudio.com/issues/detail/20069