### PR TITLE
Update VSCode.cs

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -930,7 +930,7 @@ namespace dotBunny.Unity
                 "\t\t\"**/.DS_Store\":true,\n" +
                 "\t\t\"**/.git\":true,\n" +
                 "\t\t\"**/.gitignore\":true,\n" +
-                "\t\t\"**/.gitattributes":true,\n" +
+                "\t\t\"**/.gitattributes\":true,\n" +
                 "\t\t\"**/.gitmodules\":true,\n" +
                 "\t\t\"**/.svn\":true,\n" +
 


### PR DESCRIPTION
Fixed a non-escaped double quote on 933 that was throwing a parsing error.