### PR TITLE
Escape exclusion of .gitattributes

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -930,7 +930,7 @@ namespace dotBunny.Unity
                 "\t\t\"**/.DS_Store\":true,\n" +
                 "\t\t\"**/.git\":true,\n" +
                 "\t\t\"**/.gitignore\":true,\n" +
-                "\t\t\"**/.gitattributes":true,\n" +
+                "\t\t\"**/.gitattributes\":true,\n" +
                 "\t\t\"**/.gitmodules\":true,\n" +
                 "\t\t\"**/.svn\":true,\n" +
 


### PR DESCRIPTION
This change makes the class compile again after the addition of .gitattributs