### PR TITLE
Enhance path verification and autodetection

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -50,7 +50,7 @@ namespace dotBunny.Unity
 		{
 			//Value not set, set to "" or current path is invalid, try to autodetect it
 			//If autodetect fails, a error will be printed and the default value set
-			EditorPrefs.SetString("VSCode_CodePath", autodetectCodePath);
+			EditorPrefs.SetString("VSCode_CodePath", autodetectCodePath());
 			//If its not installed or the install folder isn't a "normal" one,
 			//autodetectCodePath will print a error message to the Unity Console
 		}

--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -45,15 +45,16 @@ namespace dotBunny.Unity
         {
             get
             {
-
-#if UNITY_EDITOR_OSX
-                var newPath = "/Applications/Visual Studio Code.app";
-#elif UNITY_EDITOR_WIN
-                var newPath = ProgramFilesx86() + Path.DirectorySeparatorChar + "Microsoft VS Code" + Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "code.cmd";
-#else
-                var newPath = "/usr/bin/code";
-#endif                
-                return EditorPrefs.GetString("VSCode_CodePath", newPath);
+		string current = EditorPrefs.GetString("VSCode_CodePath", "");
+		if(current == "" || !VSCodeExists(current))
+		{
+			//Value not set, set to "" or current path is invalid, try to autodetect it
+			//If autodetect fails, a error will be printed and the default value set
+			EditorPrefs.SetString("VSCode_CodePath", autodetectCodePath);
+			//If its not installed or the install folder isn't a "normal" one,
+			//autodetectCodePath will print a error message to the Unity Console
+		}
+                return EditorPrefs.GetString("VSCode_CodePath", current);
             }
             set 
             {
@@ -366,6 +367,59 @@ namespace dotBunny.Unity
         #endregion
 
         #region Private Members
+        
+        	/// <summary>
+        	/// Determines if the current path to the code executable is valid or not (exists)
+        	/// </summary>
+        	static bool VSCodeExists(string curPath)
+        	{
+        		System.IO.FileInfo code = new System.IO.FileInfo(curPath);
+        		return code.Exists;
+        	}
+        	
+        	/// <summary>
+        	/// Print a error message to the Unity Console about not finding the code executable
+        	static void PrintNotFound()
+        	{
+        		UnityEngine.Debug.LogError("Code executable in '" + CodePath + "' not found. Check" +
+        		"Visual Studio Code installation and insert the correct path in the Properties menu");
+        	}
+        
+        	/// <summary>
+        	/// Try to find automatically the installation of VSCode
+        	/// </summary>
+        	static string autodetectCodePath() 
+        	{
+        	// FIXME: Need to query possible paths to the installation of VSCode on other OS X
+        	#if UNITY_EDITOR_OSX
+        		string possiblePaths = 
+        		{
+        			"/Applications/Visual Studio Code.app"
+        		}
+        	#elif UNITY_EDITOR_WIN
+        	// FIXME: Add additional paths which VSCode can be installed on Windows
+        		string possiblePaths = 
+        		{
+        			ProgramFilesx86() + Path.DirectorySeparatorChar + "Microsoft VS Code"
+        			+ Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar + "code.cmd"
+        		};
+        	#else
+        		string[] possiblePaths = {
+        			"/usr/bin/code",
+        			"/bin/code",
+        			"/usr/local/bin/code"
+        		};
+        	#endif
+        		for(int i = 0; i < possiblePaths.Length; i++)
+        		{
+        			if(VSCodeExists(possiblePaths[i])) 
+        			{
+        				return possiblePaths[i];
+        			}
+        		}
+        		PrintNotFound();
+        		return possiblePaths[0]; //returns the default one, printing a warning message 'executable not found'
+        	}
 
 		/// <summary>
 		/// Parse given folders as parameters and check for spaces
@@ -397,21 +451,25 @@ namespace dotBunny.Unity
         static void CallVSCode(string args)
         {
             System.Diagnostics.Process proc = new System.Diagnostics.Process();
+            if(!VSCodeExists(CodePath))
+            {
+            	PrintNotFound();
+            	return; //Executable not found. Stop execution
+            }
 
 			//Escaping spaces in the name isn't needed in a Windows environment
 			//So for OS X and Linux/Unix, call EscapePathScapes(args) instead of args
 #if UNITY_EDITOR_OSX
             proc.StartInfo.FileName = "open";
-			proc.StartInfo.Arguments = " -n -b \"com.microsoft.VSCode\" --args " + EscapePathSpaces(args);
+	    proc.StartInfo.Arguments = " -n -b \"com.microsoft.VSCode\" --args " + EscapePathSpaces(args);
             proc.StartInfo.UseShellExecute = false;
 #elif UNITY_EDITOR_WIN
             proc.StartInfo.FileName = CodePath;
-			proc.StartInfo.Arguments = args;
+	    proc.StartInfo.Arguments = EscapePathSpaces(args);
             proc.StartInfo.UseShellExecute = false;
 #else
-            //TODO: Allow for manual path to code?
             proc.StartInfo.FileName = CodePath;
-			proc.StartInfo.Arguments = EscapePathSpaces(args);
+	    proc.StartInfo.Arguments = EscapePathSpaces(args);
             proc.StartInfo.UseShellExecute = false;
 #endif
             proc.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;


### PR DESCRIPTION
Adds default paths to all platforms, check for executable existence before and on execution and (sort of) path autodetection. Also prints a error message when the specified executable file is not found in the system.
TODO: Add more default folders/paths to OS X and Windows