### PR TITLE
let VS Code open in new window

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -726,7 +726,7 @@ namespace dotBunny.Unity
             SyncSolution();
 
             // Load Project
-            CallVSCode("\"" + ProjectPath + "\" -r");
+            CallVSCode("\"" + ProjectPath + "\"");
         }
 
         /// <summary>


### PR DESCRIPTION
Thanks for building and maintaining this plugin!

Currently, the plugin passes the -r option to VS Code:

```
-r, --reuse-window
Force opening a file or folder in the last active window.
```

This plugin should not be affecting VS Code windows dedicated to other projects. This change lets VS Code open in a new window if needed.