### PR TITLE
more vertical space in preferences window

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -760,7 +760,9 @@ namespace dotBunny.Unity
             }
             EditorGUILayout.BeginVertical();
 
-            EditorGUILayout.HelpBox("Support development of this plugin, follow @reapazor and @dotbunny on Twitter.", MessageType.Info);
+            var developmentInfo = "Support development of this plugin, follow @reapazor and @dotbunny on Twitter.";
+            var versionInfo = string.Format("{0:0.00}", Version) + VersionCode + ", GitHub version @ " + string.Format("{0:0.00}", GitHubVersion);
+            EditorGUILayout.HelpBox(developmentInfo + " --- [ " + versionInfo + " ]", MessageType.None);
 
             EditorGUI.BeginChangeCheck();
             
@@ -849,17 +851,6 @@ namespace dotBunny.Unity
                 }
             }
 
-            GUILayout.FlexibleSpace();
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-
-            GUILayout.Label(
-                new GUIContent(
-                    string.Format("{0:0.00}", Version) + VersionCode,
-                    "GitHub's Version @ " + string.Format("{0:0.00}", GitHubVersion)));
-
-            EditorGUILayout.EndHorizontal();
-            EditorGUILayout.EndVertical();
         }
 
         /// <summary>


### PR DESCRIPTION
Moved version information into preexisting top info box with preexisting line break, keeping it at its two-line height. Allows space for a new item without kicking the version number out of the window.

Before:
![image](https://cloud.githubusercontent.com/assets/8858/17835609/85f652d6-6729-11e6-84b7-b71c81460e9b.png)

With this commit:
![image](https://cloud.githubusercontent.com/assets/8858/17835603/4bd831fa-6729-11e6-925d-7c3fa891aa28.png)
