### PR TITLE
Fix uncaught JavaScript exception

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -1147,13 +1147,13 @@ namespace dotBunny.Unity
                 EditorPrefs.SetString("kScriptsDefaultApp", CodePath);
 
                 // Arguments
-                if (EditorPrefs.GetString("kScriptEditorArgs") != "-r -g \"$(File):$(Line)\"")
+                if (EditorPrefs.GetString("kScriptEditorArgs") != "-r -g `$(File):$(Line)`")
                 {
                     EditorPrefs.SetString("VSCode_PreviousArgs", EditorPrefs.GetString("kScriptEditorArgs"));
                 }
 
-                EditorPrefs.SetString("kScriptEditorArgs", "-r -g \"$(File):$(Line)\"");
-                EditorPrefs.SetString("kScriptEditorArgs" + CodePath, "-r -g \"$(File):$(Line)\"");
+                EditorPrefs.SetString("kScriptEditorArgs", "-r -g `$(File):$(Line)`");
+                EditorPrefs.SetString("kScriptEditorArgs" + CodePath, "-r -g `$(File):$(Line)`");
 
 
                 // MonoDevelop Solution


### PR DESCRIPTION
When attempting to `Open C# Project`, using VS Code 1.4, there's an uncaught JavaScript exception. Changing to back ticks instead of double quotes in the `External Script Editor Args`, fixes the issue.