### PR TITLE
Fixed a crash bug.

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -40,6 +40,9 @@ namespace dotBunny.Unity
         /// </summary>
         public const string UnityDebuggerURL = "https://unity.gallery.vsassets.io/_apis/public/gallery/publisher/unity/extension/unity-debug/latest/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
 
+        // Used to keep Unity from crashing when the editor is quit
+        static bool alreadyFixedPreferences;
+
         #region Properties
 
         /// <summary>
@@ -1233,10 +1236,13 @@ namespace dotBunny.Unity
                 // Always leave editor attaching on, I know, it solves the problem of needing to restart for this
                 // to actually work
                 EditorPrefs.SetBool("AllowAttachedDebuggingOfEditor", true);
-                
             }
 
-            FixUnityPreferences();
+            if (!alreadyFixedPreferences)
+            {
+                alreadyFixedPreferences = true;
+                FixUnityPreferences();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Before this PR, Unity crashed when quitting at least in Unity 2017.4 and later. I don't remember if this was an issue in Unity 2017.3 or earlier. This fixes that crash.

With this new check, it will call 'FixUnityPreferences' when a project is opened, when it re-compiles, when it is run, and when it is stopped. Basically whenever the C# assemblies are swapped out it will still execute the function as before.

However, it will no longer call it when Unity is quit, which is when the crash would occur.