### PR TITLE
Fixed a critical drawing bug in Unity 2018.3 due to a missing EndVertical call.

### DIFF
--- a/Plugins/Editor/VSCode.cs
+++ b/Plugins/Editor/VSCode.cs
@@ -907,6 +907,7 @@ namespace dotBunny.Unity
                 }
             }
 
+            EditorGUILayout.EndVertical();
         }
 
         /// <summary>


### PR DESCRIPTION
This is a fix for where the updated preferences window in Unity 2018.3 won't draw the GUI at all for some reason if the Begin and End calls match up perfectly :\